### PR TITLE
This issue implements an endpoint responsible to receive a list of fi…

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,15 +4,15 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pylint = "*"
-autopep8 = "*"
+pylint = "==2.4.3"
+autopep8 = "==1.4.4"
 
 [packages]
 pdfminer-six = "==20181108"
-chardet = "*"
-tabula-py = "*"
+chardet = "==3.0.4"
+tabula-py = "==1.4.1"
 flask = "==1.1.1"
-flask-restful = "*"
+flask-cors = "==3.0.8"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ab10d82ba264571982556efb46759ebf8ded032a0c93ec1283d270614a3f0d13"
+            "sha256": "f4d65f4db4844c460b2c3faca80f9f21eb733971ffbea5ce02c0212a4a1fd2be"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,13 +16,6 @@
         ]
     },
     "default": {
-        "aniso8601": {
-            "hashes": [
-                "sha256:529dcb1f5f26ee0df6c0a1ee84b7b27197c3c50fc3a6321d66c544689237d072",
-                "sha256:c033f63d028b9a58e3ab0c2c7d0532ab4bfa7452bfc788fbfe3ddabd327b181a"
-            ],
-            "version": "==8.0.0"
-        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
@@ -53,13 +46,13 @@
             "index": "pypi",
             "version": "==1.1.1"
         },
-        "flask-restful": {
+        "flask-cors": {
             "hashes": [
-                "sha256:ecd620c5cc29f663627f99e04f17d1f16d095c83dc1d618426e2ad68b03092f8",
-                "sha256:f8240ec12349afe8df1db168ea7c336c4e5b0271a36982bff7394f93275f2ca9"
+                "sha256:72170423eb4612f0847318afff8c247b38bd516b7737adfc10d1c2cdbb382d16",
+                "sha256:f4d97201660e6bbcff2d89d082b5b6d31abee04b1b3003ee073a6fd25ad1d69a"
             ],
             "index": "pypi",
-            "version": "==0.3.7"
+            "version": "==3.0.8"
         },
         "itsdangerous": {
             "hashes": [
@@ -267,26 +260,29 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:02b260c8deb80db09325b99edf62ae344ce9bc64d68b7a634410b8e9a568edbf",
-                "sha256:18f9c401083a4ba6e162355873f906315332ea7035803d0fd8166051e3d402e3",
-                "sha256:1f2c6209a8917c525c1e2b55a716135ca4658a3042b5122d4e3413a4030c26ce",
-                "sha256:2f06d97f0ca0f414f6b707c974aaf8829c2292c1c497642f63824119d770226f",
-                "sha256:616c94f8176808f4018b39f9638080ed86f96b55370b5a9463b2ee5c926f6c5f",
-                "sha256:63b91e30ef47ef68a30f0c3c278fbfe9822319c15f34b7538a829515b84ca2a0",
-                "sha256:77b454f03860b844f758c5d5c6e5f18d27de899a3db367f4af06bec2e6013a8e",
-                "sha256:83fe27ba321e4cfac466178606147d3c0aa18e8087507caec78ed5a966a64905",
-                "sha256:84742532d39f72df959d237912344d8a1764c2d03fe58beba96a87bfa11a76d8",
-                "sha256:874ebf3caaf55a020aeb08acead813baf5a305927a71ce88c9377970fe7ad3c2",
-                "sha256:9f5caf2c7436d44f3cec97c2fa7791f8a675170badbfa86e1992ca1b84c37009",
-                "sha256:a0c8758d01fcdfe7ae8e4b4017b13552efa7f1197dd7358dc9da0576f9d0328a",
-                "sha256:a4def978d9d28cda2d960c279318d46b327632686d82b4917516c36d4c274512",
-                "sha256:ad4f4be843dace866af5fc142509e9b9817ca0c59342fdb176ab6ad552c927f5",
-                "sha256:ae33dd198f772f714420c5ab698ff05ff900150486c648d29951e9c70694338e",
-                "sha256:b4a2b782b8a8c5522ad35c93e04d60e2ba7f7dcb9271ec8e8c3e08239be6c7b4",
-                "sha256:c462eb33f6abca3b34cdedbe84d761f31a60b814e173b98ede3c81bb48967c4f",
-                "sha256:fd135b8d35dfdcdb984828c84d695937e58cc5f49e1c854eb311c4d6aa03f4f1"
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "mccabe": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -1,33 +1,83 @@
-from flask import Flask
-from flask_restful import Resource, Api
+import os
+import urllib.request
+from flask import Flask, request, redirect, jsonify
+from werkzeug.utils import secure_filename
+from flask_cors import CORS, cross_origin
+
+UPLOAD_FOLDER = 'uploads/files/'
 
 app = Flask(__name__)
-api = Api(app)
 
+cors = CORS(app)
+app.config['CORS_HEADERS'] = 'Content-Type'
 
-class Upload(Resource):
-    def get(self):
-        return {
-            "summary": {
-                "positions": [
-                    {
-                        "stock": "ITAUSA",
-                        "averagePrice": 21.10,
-                        "sellingPrice": 10.00,
-                        "profitLoss": -11.10
-                    },
-                    {
-                        "stock": "ITAUSA",
-                        "averagePrice": 21.10,
-                        "sellingPrice": 30.00,
-                        "profitLoss": 8.90
-                    }
-                ],
-                "totalPL": -2.2,
-                "tax": 0
-            }
-        }
-api.add_resource(Upload, '/upload')
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
+
+ALLOWED_EXTENSIONS = set(['pdf'])
+
+def allowed_file(filename):
+	return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@app.route('/upload', methods=['POST'])
+@cross_origin()
+def upload_file():
+	# check if the post request has the file part
+	if 'files[]' not in request.files:
+		resp = jsonify({'message': 'No file part in the request'})
+		resp.status_code = 400
+		return resp
+
+	files = request.files.getlist('files[]')
+
+	errors = {}
+	success = False
+
+	for file in files:
+		if file and allowed_file(file.filename):
+			filename = secure_filename(file.filename)
+			file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+			success = True
+		else:
+			errors[file.filename] = 'File type is not allowed'
+	
+	if success and errors:
+		errors['message'] = 'File(s) successfully uploaded'
+		resp = jsonify(errors)
+		resp.status_code = 500
+		return resp
+	if success:
+		resp = jsonify(
+            {
+                'summary': {
+                    'positions': [
+                        {
+                            'stock': 'ITAUSA',
+                            'averagePrice': 21.10,
+                            'sellingPrice': 10.00,
+                            'profitLoss': -11.10
+                        },
+                        {
+                            'stock': 'ITAUSA',
+                            'averagePrice': 21.10,
+                            'sellingPrice': 30.00,
+                            'profitLoss': 8.90
+                        }
+                    ],
+                    'totalPL': -2.2,
+                    'tax': 0
+                }
+            })
+		resp.status_code = 201
+		return resp
+	else:
+		resp = jsonify(errors)
+		resp.status_code = 500
+		return resp
 
 if __name__ == "__main__":
+    # create the uploads directory if it doesn't exist
+    if not os.path.exists(UPLOAD_FOLDER):
+        os.makedirs(UPLOAD_FOLDER)
+
     app.run(host='0.0.0.0', debug=True)


### PR DESCRIPTION
This issue implements an endpoint responsible to receive a list of files and persist them in the file system of the server.
    
The request must be a **POST** to **'/uploads'** providing an array of files named **'files[]'**. 

Initially, only **.pdf** files are allowed.

This endpoint also returns a mocked summary of stock positions, which will be replaced by the scrapper and taxes calculation services.